### PR TITLE
0.13.1

### DIFF
--- a/fancy/config/__init__.py
+++ b/fancy/config/__init__.py
@@ -23,6 +23,6 @@ from .config_loaders import (
 )
 from .base_config import BaseConfig
 
-
 from .config_loader_factory import ConfigLoaderFactory
 from .config_factory import ConfigFactory
+from .consts import IGNORED_NAME

--- a/fancy/config/base_config.py
+++ b/fancy/config/base_config.py
@@ -2,7 +2,7 @@ from abc import ABC
 import warnings
 from typing import Dict, List, overload, Any, Callable, Optional
 
-from . import ConfigStructure, ConfigContext, exc, PlaceHolder, ConfigStructureVisitor, DictConfigLoader
+from . import ConfigStructure, ConfigContext, exc, PlaceHolder, ConfigStructureVisitor, DictConfigLoader, consts
 from . import Option
 from .utils import inspect, Dispatcher, DispatcherError
 from . import visitors
@@ -172,8 +172,12 @@ class BaseConfig(ConfigStructure, ConfigContext, ABC):
     @classmethod
     def get_name_mapping(cls) -> Dict[str, str]:
         if cls._name_mapping is None:
-            cls._name_mapping = {
-                placeholder.name: attr_name
-                for attr_name, placeholder in cls.get_all_placeholders().items()
-            }
+            name_mapping = {}
+            for attr_name, placeholder in cls.get_all_placeholders().items():
+                if placeholder.name == consts.IGNORED_NAME:
+                    continue
+                if placeholder.name in name_mapping:
+                    raise exc.DuplicatedNameError()
+                name_mapping[placeholder.name] = attr_name
+            cls._name_mapping = name_mapping
         return cls._name_mapping

--- a/fancy/config/base_config.py
+++ b/fancy/config/base_config.py
@@ -1,6 +1,6 @@
 from abc import ABC
 import warnings
-from typing import Dict, List, overload, Any, Callable
+from typing import Dict, List, overload, Any, Callable, Optional
 
 from . import ConfigStructure, ConfigContext, exc, PlaceHolder, ConfigStructureVisitor, DictConfigLoader
 from . import Option
@@ -10,10 +10,10 @@ from ..config import BaseConfigLoader
 
 
 class BaseConfig(ConfigStructure, ConfigContext, ABC):
-    _name_mapping: Dict[str, str] = None
-    _all_placeholders: Dict[str, PlaceHolder] = None
-    _all_options: Dict[str, Option] = None
-    _all_required_options: List[Option] = None
+    _name_mapping: Optional[Dict[str, str]] = None
+    _all_placeholders: Optional[Dict[str, PlaceHolder]] = None
+    _all_options: Optional[Dict[str, Option]] = None
+    _all_required_options: Optional[List[Option]] = None
     _loader: BaseConfigLoader = None
 
     _method_init_ = Dispatcher(is_method=True)
@@ -43,6 +43,12 @@ class BaseConfig(ConfigStructure, ConfigContext, ABC):
     @_method_init_.implement
     def __init__(self, *args, **kwargs):
         ...
+
+    def __init_subclass__(cls, **kwargs):
+        cls._name_mapping = None
+        cls._all_placeholders = None
+        cls._all_options = None
+        cls._all_required_options = None
 
     def load(self, loader: 'BaseConfigLoader') -> None:
         self._loader = loader

--- a/fancy/config/base_config.py
+++ b/fancy/config/base_config.py
@@ -133,6 +133,10 @@ class BaseConfig(ConfigStructure, ConfigContext, ABC):
             DeprecationWarning
         )
 
+    def clear(self) -> None:
+        for placeholder in self.get_all_placeholders().values():
+            placeholder.__delete__(self)
+
     def __repr__(self):
         return str(self.to_dict())
 

--- a/fancy/config/consts.py
+++ b/fancy/config/consts.py
@@ -1,0 +1,8 @@
+IGNORED_NAME = '_'
+"""
+Create a placeholder with this name will cause the placeholder cannot be loaded using a ConfigLoader
+
+.. note:: It can be use with cfg.Lazy. A Lazy with this name will be ignored in to_dict and __setitem__ of its owner
+
+.. warning:: Don't use it with required=True
+"""

--- a/fancy/config/exc.py
+++ b/fancy/config/exc.py
@@ -5,3 +5,9 @@ class ClassNotFoundException(Exception):
 
 class ContextNotLoadedError(RuntimeError):
     pass
+
+
+class DuplicatedNameError(RuntimeError):
+    """
+    Detects a config class has duplicated name in its placeholders.
+    """

--- a/fancy/config/option.py
+++ b/fancy/config/option.py
@@ -53,7 +53,8 @@ class Option(PlaceHolder):
         # initialize value
         if self._should_assign_default_value(instance):
             if self._default is None and not self._nullable:
-                raise AttributeError("attribute must assign the value before access it.")
+                raise AttributeError(
+                    f"attribute '{self.__name__}' of '{owner.__name__}' object must be assigned before accessing.")
 
             self.__set__(instance, self._default)
 

--- a/fancy/config/placeholder.py
+++ b/fancy/config/placeholder.py
@@ -20,10 +20,24 @@ class PlaceHolder:
         if self._config_name is None:
             self._config_name = name
 
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+
+        try:
+            return vars(instance)[self.__name__]
+        except KeyError:
+            raise AttributeError(
+                f"attribute '{self.__name__}' of '{owner.__name__}' object must be assigned before accessing."
+            )
+
     def __set__(self, instance: 'BaseConfig', raw_value):
         if self.readonly:
             raise AttributeError(f"{self.name} can't be set")
         vars(instance)[self.__name__] = raw_value
+
+    def __delete__(self, instance: 'BaseConfig'):
+        vars(instance).pop(self.__name__, None)
 
     @property
     def name(self) -> str:

--- a/fancy/config/visitors/to_collection_visitor.py
+++ b/fancy/config/visitors/to_collection_visitor.py
@@ -1,6 +1,6 @@
 from typing import Collection, List, Optional, Mapping, Sequence, Any, Dict, TYPE_CHECKING, Callable
 
-from .. import ConfigStructureVisitor, ConfigListStructure, ConfigStructure, PlaceHolder
+from .. import ConfigStructureVisitor, ConfigListStructure, ConfigStructure, PlaceHolder, consts
 
 if TYPE_CHECKING:
     from .. import BaseConfig
@@ -27,7 +27,9 @@ class ToCollectionVisitor(ConfigStructureVisitor):
         if self._filter is not None:
             placeholders = filter(self._filter, placeholders)
         for placeholder in placeholders:
-            if not placeholder.is_assigned(structure) or placeholder.hidden:
+            if not placeholder.is_assigned(structure) or \
+                    placeholder.hidden or \
+                    placeholder.name == consts.IGNORED_NAME:
                 continue
             self._resolve_value(structure[placeholder.name])
             result[placeholder.name] = self.result_stack.pop()

--- a/tests/integration/inheritance/test_inherit_with_named_options.py
+++ b/tests/integration/inheritance/test_inherit_with_named_options.py
@@ -1,0 +1,18 @@
+from fancy import config as cfg
+
+
+def test_inherit_with_named_options():
+    class SuperConfig(cfg.BaseConfig):
+        a: str = cfg.Option(name="A")
+
+    class SubConfig(SuperConfig):
+        b: str = cfg.Option(name="B")
+
+    super_data = {"A": '1'}
+    sc = SuperConfig(super_data)
+    assert sc.a == '1'  # load super config before sub config
+
+    sub_data = {"A": '1', 'B': '2'}
+    c = SubConfig(sub_data)
+    assert c.a == '1'
+    assert c.b == '2'

--- a/tests/integration/option/test_option_common_behaviors.py
+++ b/tests/integration/option/test_option_common_behaviors.py
@@ -12,6 +12,7 @@ def test_required_option():
         MyConfig({})
     c = MyConfig(x=1)  # y is not required, this statement shouldn't raise exceptions
     assert c.x == 1
-    with pytest.raises(AttributeError, match="attribute must assign the value before access it."):
+    with pytest.raises(AttributeError,
+                       match="attribute 'y' of 'MyConfig' object must be assigned before accessing."):
         # noinspection PyStatementEffect
         c.y

--- a/tests/integration/test_config_clearing.py
+++ b/tests/integration/test_config_clearing.py
@@ -1,0 +1,55 @@
+from typing import List
+
+import pytest
+
+from fancy import config as cfg
+
+
+class MyConfig(cfg.BaseConfig):
+    a: int = cfg.Option(type=int, required=True)
+    b: str = cfg.Option(type=str, default="default text")
+    c: List[int] = cfg.Option(type=[int])
+    d: str = cfg.PlaceHolder()  # custom state marked with Placeholder
+    e: int  # a custom state marking
+
+    def post_load(self):
+        self.d = str(self.a + 2)
+        self.e = self.a ** 2
+
+    def clear(self):
+        super().clear()
+        del self.e  # clear an unmarked custom state manually
+
+
+# Test case 1: Clear a fully loaded config
+def test_clear_loaded_config():
+    config = MyConfig(a=1, b="a string", c=[1, 2, 3, 4])
+    config.d = "custom state"
+    config.clear()
+
+    with pytest.raises(AttributeError, match="attribute 'a' of 'MyConfig' object must be assigned before accessing."):
+        _ = config.a
+
+    assert config.b == "default text"
+
+    with pytest.raises(AttributeError, match="attribute 'c' of 'MyConfig' object must be assigned before accessing."):
+        _ = config.c
+
+    with pytest.raises(AttributeError, match="attribute 'd' of 'MyConfig' object must be assigned before accessing."):
+        _ = config.d
+
+    with pytest.raises(AttributeError, match="'MyConfig' object has no attribute 'e'"):
+        _ = config.e
+
+
+# Test case 2: Load config without default_values after clearing
+def test_load_config_without_default_values_after_clear():
+    config = MyConfig(a=1, b="a string", c=[1, 2, 3, 4])
+    config.clear()
+    config.load(cfg.DictConfigLoader({"a": 3, "c": [5, 6, 7, 8]}))
+
+    assert config.a == 3
+    assert config.b == "default text"
+    assert config.c == [5, 6, 7, 8]
+    assert config.d == '5'
+    assert config.e == 9

--- a/tests/integration/test_named_placeholder.py
+++ b/tests/integration/test_named_placeholder.py
@@ -1,0 +1,53 @@
+import pytest
+
+from fancy import config as cfg
+from fancy.config.exc import DuplicatedNameError
+
+
+def test_det_duplicated_placeholder_name():
+    class MyConfig(cfg.BaseConfig):
+        n = cfg.Option(name="s", type=int)
+        s = cfg.Lazy(lambda c: 40)  # dup!!!!
+
+    with pytest.raises(DuplicatedNameError):
+        MyConfig(s=1)
+
+
+def test_ignored_name():
+    class MyConfig(cfg.BaseConfig):
+        # This is only for assigning, it can never be loaded
+        a: int = cfg.Option(name=cfg.IGNORED_NAME, type=int)
+        b: int = cfg.Option(type=int)
+
+    c = MyConfig(b=2)
+    assert c.b == 2
+
+    with pytest.raises(AttributeError):
+        _ = c.a
+
+    c.a = 1
+    assert c.a == 1
+
+
+def test_ignored_name_cannot_be_loaded():
+    class MyConfig(cfg.BaseConfig):
+        # This is only for assigning, it can never be loaded
+        a: int = cfg.Option(name=cfg.IGNORED_NAME, type=int)
+        b: int = cfg.Option(type=int)
+
+    with pytest.raises(KeyError, match=r'not contains the config named a, value: 1'):
+        MyConfig(a=1, b=2)
+
+
+def test_ignore_name_and_to_dict():
+    class MyConfig(cfg.BaseConfig):
+        a: int = cfg.Option(type=int)
+        b: str = cfg.Lazy(lambda c: f'n{c.a}', name=cfg.IGNORED_NAME)
+
+    data = {'a': 1}
+    c = MyConfig(data)
+
+    assert c.a == 1
+    assert c.b == 'n1'
+
+    assert c.to_dict() == data  # to dict is not containing MyConfig.b and can load-back to MyConfig


### PR DESCRIPTION
Close #35 , #33 , and #29 
Refine error message
Add a special placeholder name `cfg.IGNORED_NAME` to ignore a placeholder in the dict-like operation of the config class