### PR TITLE
Version v0.13.4

### DIFF
--- a/makefile
+++ b/makefile
@@ -9,10 +9,10 @@ clean:
 	rm -rf ./dist
 
 upload_test: clean all
-	twine upload --repository testpypi dist/*
+	twine upload --repository testpypi dist/*.whl
 
 upload: clean all
-	twine upload dist/*
+	twine upload dist/*.whl
 
 test:
 	PYTHONPATH=src pytest tests 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with requirements_file.open() as fp:
 
 setup(
     name="fancy-config",
-    version="0.13.3",
+    version="0.13.4",
     packages=find_namespace_packages("src"),
     package_dir={"": "src"},
     package_data={

--- a/src/fancy/config/__init__.pyi
+++ b/src/fancy/config/__init__.pyi
@@ -113,7 +113,7 @@ class Option[GV, SV, N](PlaceHolder[GV | N]):
         *,
         required: bool = False,
         nullable: Literal[True],
-        default: _SV | None = None,
+        default: Sequence[_SV] | None = None,
         type: _Nested[_SV, _GV],
         name: str | None = None,
         description: str | None = None,

--- a/tests/integration/option/test_list_configuration.py
+++ b/tests/integration/option/test_list_configuration.py
@@ -83,3 +83,38 @@ def test_to_dict_with_list():
     assert config_dict["servers"][0]["port"] == 8080
     assert config_dict["servers"][1]["host"] == "server2.example.com"
     assert config_dict["servers"][1]["port"] == 80
+
+
+class NullableServerConfig(cfg.BaseConfig):
+        host = cfg.Option(type=str, required=True)
+        port = cfg.Option(type=int, default=80)
+        tags = cfg.Option(type=[str], default=["server"], nullable=True)  # Nullable list of strings
+
+def test_nullable_list_elements():
+    # Test with nullable list elements
+
+    config = NullableServerConfig({
+        "host": "server1.example.com",
+        "tags": None  # Explicitly set to None
+    })
+    
+    assert config.tags is None  # Should be None
+
+def test_nullable_list_elements_without_value():
+    # Test with nullable list elements without explicitly setting them
+    config = NullableServerConfig({
+        "host": "server1.example.com"
+    })
+
+    assert config.tags is not None  # Should not be None    
+    assert config.tags == ["server"]  # Should use default value
+
+    config.tags.append("web")
+
+    another_config = NullableServerConfig({
+        "host": "server2.example.com"
+    })
+
+    assert another_config.tags is not None  # Should not be None
+    # Check the default value does not change
+    assert another_config.tags == ["server"]  # Should use default value


### PR DESCRIPTION
This pull request includes several changes to the `fancy-config` project, focusing on improving the handling of nullable list elements, updating the package version, and refining the upload process in the makefile. The most important changes include modifying the `Option` class to support nullable sequences, adding new tests for nullable list elements, and updating the `setup.py` version.

Enhancements to nullable list elements:

* [`src/fancy/config/__init__.pyi`](diffhunk://#diff-327333000ed6115ee60f747650ec12295bcbc9e02078d04a6b9f4b21db535b0fL116-R116): Modified the `Option` class to allow the `default` parameter to be a sequence, supporting nullable list elements.

Testing improvements:

* [`tests/integration/option/test_list_configuration.py`](diffhunk://#diff-e0ce69c261f26f625cf83001aa89392a95ae418b761d8f89872bc58f883822e5R86-R120): Added new tests for nullable list elements in the `NullableServerConfig` class to ensure proper handling of default values and explicit `None` assignments.

Build and release process updates:

* [`makefile`](diffhunk://#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0L12-R15): Updated the `upload_test` and `upload` targets to only upload `.whl` files, avoiding PyPI deprecation notice.

Version update:

* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L18-R18): Bumped the package version from `0.13.3` to `0.13.4` to reflect the new changes and improvements.